### PR TITLE
Document PAT workflow for Decap CMS

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,16 @@
+# Assistant Notes
+
+## Summary of changes
+- Added an informational banner to `/admin` explaining the personal access token (PAT) login workflow for Decap CMS.
+- Rewrote `admin/README.md` to focus on the PAT-based authentication process and day-to-day editing steps.
+- Confirmed that existing Decap CMS configuration (`admin/config.yml`) already targets the repository's `main` branch and requires no additional changes.
+
+## Outstanding actions for the site owner
+1. Generate a classic GitHub personal access token with the `repo` scope by visiting <https://github.com/settings/tokens>.
+2. Store the token securely (for example in a password manager).
+3. Use the token when clicking **Log in with token** on <https://harryluoo.github.io/admin/>.
+4. Revoke and regenerate the token if it is ever exposed or when you want to rotate credentials.
+
+## Observations
+- Future-dated posts (e.g., the 2025 entry) will stay hidden on the public site until their dates arrive unless `future: true` is added to `_config.yml`.
+- The custom local-development script embedded in `admin/index.html` is untouched and continues to support the local proxy workflow described in `admin/README.md`.

--- a/admin/README.md
+++ b/admin/README.md
@@ -6,61 +6,36 @@ Your website is now fully functional with:
 - ✅ Complete navigation between all pages (Home, About, Categories, Tags)
 - ✅ GitHub Pages deployment at https://harryluoo.github.io/
 - ✅ Decap CMS interface available at /admin/
-- ⚠️ CMS authentication requires additional setup (see below)
+- ⚠️ CMS authentication requires a personal access token (see below)
 
 ## CMS Authentication Setup
 
-The CMS requires OAuth authentication to edit your site. Since GitHub Pages doesn't provide server-side functionality, you have several options:
+For a single editor you can sign in using a GitHub personal access token (PAT). This keeps hosting on
+GitHub Pages and avoids running a separate OAuth service.
 
-### Option 1: Use GitHub Personal Access Token (Simplest for single user)
+### One-time token creation (manual step)
 
-1. Go to GitHub Settings > Developer settings > Personal access tokens
-2. Generate a new token with `repo` scope
-3. Use this token to authenticate (Note: This is only suitable for personal use, not for multiple editors)
+1. Visit <https://github.com/settings/tokens>.
+2. Choose **Generate new token (classic)**.
+3. Give the token a descriptive name (for example `Decap CMS PAT`).
+4. Tick the **repo** scope so the CMS can read and write content in this repository.
+5. Create the token and copy it somewhere safe (a password manager is recommended).
 
-### Option 2: Set up a Free OAuth Backend Service
+### Day-to-day editing
 
-You can use one of these free services:
+1. Open <https://harryluoo.github.io/admin/>.
+2. Click **Log in with token**.
+3. Paste the PAT from the step above.
+4. Edit content and click **Publish**. Decap CMS commits straight to `main`.
 
-#### A. Netlify (Recommended - Most Reliable)
-1. Create a free Netlify account at https://netlify.com
-2. Deploy your site to Netlify (you can keep GitHub Pages as well)
-3. Enable Netlify Identity in your Netlify site settings
-4. Update `admin/config.yml`:
-```yaml
-backend:
-  name: git-gateway
-  branch: main
-```
-5. Add the Netlify Identity Widget to your site
+If you ever revoke or rotate the token, just mint a new one with the same scope and reuse the workflow
+above.
 
-#### B. Use Vite-plugin-decap-cms-oauth
-1. Create a new GitHub OAuth App:
-   - Go to GitHub Settings > Developer settings > OAuth Apps
-   - Click "New OAuth App"
-   - Application name: Your Site CMS
-   - Homepage URL: https://harryluoo.github.io
-   - Authorization callback URL: https://your-oauth-provider.vercel.app/callback
-2. Deploy the OAuth provider to Vercel (free):
-   - Fork https://github.com/marcodallaba/netlify-cms-github-oauth-provider
-   - Deploy to Vercel
-   - Set environment variables with your GitHub OAuth App credentials
-3. Update `admin/config.yml`:
-```yaml
-backend:
-  name: github
-  repo: HarryLuoo/harryluoo.github.io
-  branch: main
-  base_url: https://your-oauth-provider.vercel.app
-  auth_endpoint: auth
-```
+### Alternative backends (optional)
 
-### Option 3: Use GitHub.dev (Alternative Editor)
-
-For quick edits without CMS:
-1. Press `.` (period) on your GitHub repository page
-2. This opens GitHub.dev - a web-based VS Code editor
-3. Make edits directly and commit from the browser
+If you later decide to add more collaborators, consider wiring the CMS to a multi-user backend such as
+Netlify Identity/Git Gateway or a self-hosted OAuth proxy. The previous revision of this document captured
+those options and can be recovered from Git history when needed.
 
 ## Local Development with CMS
 
@@ -113,31 +88,8 @@ backend:
 3. Make changes locally
 4. Push to GitHub
 
-### With CMS (After OAuth Setup)
+### With CMS (Using PAT)
 1. Go to https://harryluoo.github.io/admin/
-2. Login with GitHub
+2. Log in with your personal access token
 3. Edit content through the visual interface
 4. Save and publish changes
-
-## Troubleshooting
-
-### Issue: "404: NOT_FOUND" when logging in
-- This means the OAuth provider isn't set up yet
-- Follow one of the authentication setup options above
-
-### Issue: Local server shows errors
-- Make sure Ruby and Jekyll are installed
-- Run `bundle install` to install dependencies
-- Use the standard command: `bundle exec jekyll serve`
-
-### Issue: Changes not showing on GitHub Pages
-- Wait a few minutes for GitHub Pages to rebuild
-- Check the Actions tab in your repository for build status
-- Clear browser cache and refresh
-
-## Next Steps
-
-1. Choose and implement an authentication method from the options above
-2. Consider adding more content to your site
-3. Customize the theme and styling
-4. Add a custom domain if desired

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,6 +7,25 @@
   <title>Content Manager</title>
 </head>
 <body>
+  <main style="font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 42rem; margin: 2rem auto; padding: 1.5rem; border: 1px solid #d0d7de; border-radius: 0.75rem; background: #fff; box-shadow: 0 10px 30px rgba(27, 31, 35, 0.08);">
+    <h1 style="margin-top: 0; font-size: 1.8rem;">Decap CMS access</h1>
+    <p style="line-height: 1.6;">
+      To edit the site directly in your browser, click the <strong>Log in with token</strong> button below.
+      Generate a classic GitHub personal access token with <code>repo</code> scope and paste it into the prompt
+      when asked. Your token never leaves your browser&mdash;Decap CMS uses it to commit changes straight to
+      <code>main</code> on GitHub.
+    </p>
+    <ol style="line-height: 1.6; padding-left: 1.25rem;">
+      <li>Open <a href="https://github.com/settings/tokens" target="_blank" rel="noopener">GitHub &rarr; Developer settings &rarr; Personal access tokens</a>.</li>
+      <li>Create a <em>classic</em> token that includes the <code>repo</code> scope.</li>
+      <li>Return here, choose <strong>Log in with token</strong>, and paste the token when prompted.</li>
+    </ol>
+    <p style="margin-bottom: 0; line-height: 1.6;">
+      Store the token in a password manager. Revoke it from GitHub if you ever suspect it is exposed, then
+      mint a new one and repeat the login process.
+    </p>
+  </main>
+
   <!-- Include the script that builds the page and powers Decap CMS -->
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- add on-page guidance in the Decap CMS entry point for logging in with a GitHub personal access token
- rewrite the admin README so the PAT-based authentication flow is the default path for single editors
- document the changes and owner follow-up tasks in AGENT.md

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e15c5510d483299af020d6af1bebae