### PR TITLE
Fix GitHub backend selection for PAT login

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -188,7 +188,12 @@
           return;
         }
 
-        var BaseBackend = backendEntry.init;
+        var BaseBackend = backendEntry && (backendEntry.default || backendEntry);
+        if (typeof BaseBackend !== 'function') {
+          console.error('Unexpected Decap CMS GitHub backend shape.', backendEntry);
+          CMS.init({ config: { load_config_file: true } });
+          return;
+        }
 
         class GitHubPatBackend extends BaseBackend {
           authComponent() {


### PR DESCRIPTION
## Summary
- resolve the Decap CMS GitHub backend constructor from the module export before extending it
- add a defensive fallback if the backend entry is unexpectedly shaped

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e7f64299fc832986d7d7ec493fbf79