### PR TITLE
Use CMS React library when customizing Decap auth

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -171,14 +171,28 @@
     (function () {
       function initializeCms() {
         var CMS = window.CMS;
-        var React = window.React;
 
-        if (!CMS || !React) {
-          console.error('Decap CMS failed to expose the expected globals.');
-          if (CMS) {
-            CMS.init({ config: { load_config_file: true } });
-          }
+        if (!CMS) {
+          console.error('Decap CMS failed to expose the CMS global.');
           return;
+        }
+
+        var React = null;
+        if (typeof CMS.getLibrary === 'function') {
+          var ReactLib = CMS.getLibrary('react');
+          if (ReactLib) {
+            React = ReactLib.default || ReactLib;
+          }
+        }
+
+        if (!React && typeof window !== 'undefined') {
+          React = window.React;
+        }
+
+        if (!React) {
+          console.error(
+            'Decap CMS React library could not be located; token login UI disabled.'
+          );
         }
 
         var backendEntry = CMS.getBackend('github');
@@ -198,10 +212,25 @@
         class GitHubPatBackend extends BaseBackend {
           authComponent() {
             var OriginalComponent = super.authComponent();
-            var React = window.React;
+
+            if (!React) {
+              return OriginalComponent;
+            }
+
             var useState = React.useState;
             var useRef = React.useRef;
             var useEffect = React.useEffect;
+
+            if (
+              typeof useState !== 'function' ||
+              typeof useRef !== 'function' ||
+              typeof useEffect !== 'function'
+            ) {
+              console.error(
+                'React hooks unavailable; falling back to default Decap CMS auth UI.'
+              );
+              return OriginalComponent;
+            }
 
             function TokenCard(props) {
               var onLogin = props.onLogin;


### PR DESCRIPTION
## Summary
- resolve React from Decap CMS libraries with a window fallback so the PAT UI uses the same React instance as the rest of the app
- keep the GitHub PAT backend registered even if React hooks are unavailable, logging clear errors when the custom UI cannot load

## Testing
- bundle exec jekyll serve --detach

------
https://chatgpt.com/codex/tasks/task_e_68e7f80d45588329b1e877d7dc588413