### PR TITLE
Handle async GitHub backend in PAT wrapper

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -446,10 +446,12 @@
           var backendResult = resolveBackendInstance(arguments);
 
           if (backendResult && typeof backendResult.then === 'function') {
-            console.warn(
-              'GitHub PAT backend constructor received an asynchronous backend; returning the unresolved result.'
-            );
-            return backendResult;
+            return backendResult.then(function (backendInstance) {
+              if (backendInstance && typeof backendInstance === 'object') {
+                attachPatAuth(backendInstance);
+              }
+              return backendInstance;
+            });
           }
 
           if (backendResult && typeof backendResult === 'object') {


### PR DESCRIPTION
## Summary
- update the GitHub PAT backend wrapper to await asynchronous backend initialization before patching the auth component
- treat promise-based backend resolution as a standard path by removing the warning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e80532186c8329b11efc0e4a9e322a